### PR TITLE
By default, disable SSL for proxy, to avoid browser cert complaints.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,7 @@ ARG GIT_DIFF="unknown"
 ENV GIT_BRANCH=${GIT_BRANCH}
 ENV GIT_COMMIT=${GIT_COMMIT}
 ENV GIT_DIFF=${GIT_DIFF}
+ENV SSL=0
 
 LABEL org.opencontainers.image.authors="opensource@aryn.ai"
 LABEL git_branch=${GIT_BRANCH}

--- a/openai-proxy/py_proxy/proxy.py
+++ b/openai-proxy/py_proxy/proxy.py
@@ -213,7 +213,6 @@ def healthz(arg=None):
 
 if __name__ == '__main__':
     # Use gevent WSGIServer for asynchronous behavior
-    kwargs = {}
     if os.environ.get("SSL", "1") == "0":
         print("Proxy not serving over SSL.")
         http_server = WSGIServer(('0.0.0.0', PORT), app)

--- a/openai-proxy/py_proxy/proxy.py
+++ b/openai-proxy/py_proxy/proxy.py
@@ -213,8 +213,13 @@ def healthz(arg=None):
 
 if __name__ == '__main__':
     # Use gevent WSGIServer for asynchronous behavior
-    http_server = WSGIServer(('0.0.0.0', PORT), app,
-                             certfile=f"{HOST}-cert.pem",
-                             keyfile=f"{HOST}-key.pem")
+    kwargs = {}
+    if os.environ.get("SSL", "1") == "0":
+        print("Proxy not serving over SSL.")
+        http_server = WSGIServer(('0.0.0.0', PORT), app)
+    else:
+        http_server = WSGIServer(('0.0.0.0', PORT), app,
+                                 certfile=f"{HOST}-cert.pem",
+                                 keyfile=f"{HOST}-key.pem")
     print(f"Serving on {PORT}...")
     http_server.serve_forever()


### PR DESCRIPTION
This is because we're using self-signed certificates.
Set environment variable SSL=1 to get HTTPS.
Set environment variable SSL=0 to get HTTP.
Docker build defaults SSL=0.